### PR TITLE
[feature] Display crash message on "unhandled" exception

### DIFF
--- a/pontu_gui.py
+++ b/pontu_gui.py
@@ -128,3 +128,27 @@ class GUIState():
         textRect = text.get_rect()
         textRect.center = (self.size * 100 - 100, self.size * 100 - 20)
         self.screen.blit(text, textRect)
+
+    def display_crash(self, state) -> None:
+        """Display a crash message in the PyGame window"""
+        # Draw board and current game state
+        self.screen.fill(0)
+        self.display_state(state, display_current_player=False)
+
+        # Message font
+        font = pygame.font.Font("freesansbold.ttf", 24)
+        text = font.render(" The game crashed! ", True, "yellow", "black")
+
+        textRect = text.get_rect()
+        textRect.center = ((self.size*2-1)*25, self.size * 100 - 30)
+        self.screen.blit(text, textRect)
+
+        # Update screen
+        pygame.display.flip()
+
+        running = True
+        while running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    running = False

--- a/pontu_play.py
+++ b/pontu_play.py
@@ -8,6 +8,13 @@ if __name__ == '__main__':
   parser.add_argument("-t", help="time out: total number of seconds credited to each AI player")
   parser.add_argument("-f", help="indicates the player (0 or 1) that plays first; random otherwise")
   parser.add_argument("-g", help="display GUI (true or false); by default true")
+  parser.add_argument(
+    "-v",
+    "--verbose",
+    action="count",
+    default=0,
+    help="Increase output verbosity (maximum is 3)"
+  )
   args = parser.parse_args()
 
   agent0 = args.ai0 if args.ai0 != None else "human_agent"
@@ -15,6 +22,7 @@ if __name__ == '__main__':
   time_out = float(args.t) if args.t != None else 900.0
   first = int(args.f) if args.f == '1' or args.f == '0' else None
   display_gui = args.g == None or args.g.lower() == "true"
+  verbosity = args.verbose if args.verbose < 4 else 3
 
   if (agent0 == "human_agent" or agent1 == "human_agent") and display_gui == False:
     print('The GUI must be diplayed if a human agent is playing')
@@ -27,5 +35,5 @@ if __name__ == '__main__':
   agent0.set_id(0)
   agent1 = getattr(__import__(agent1), 'MyAgent')()
   agent1.set_id(1)
-  res = play_game(initial_state, [agent0.get_name(), agent1.get_name()], [agent0, agent1], time_out, display_gui)
+  res = play_game(initial_state, [agent0.get_name(), agent1.get_name()], [agent0, agent1], time_out, display_gui, verbosity)
   print(res)

--- a/pontu_tools.py
+++ b/pontu_tools.py
@@ -79,10 +79,11 @@ def play_game(init_state, names, players, total_time, display_gui, verbosity):
     # and tell the user (watching the screen) that there was an error
     # Don't display the winner - there is non on game crash, so it
     # would be a tie, which can lead to confusion.
-    if crashed != -1:
-        gui.display_crash(state)
-    elif display_gui:
-        gui.display_winner(state)
+    if display_gui:
+        if crashed != -1:
+            gui.display_crash(state)
+        else:
+            gui.display_winner(state)
 
     # output the result of the game: 0 if player 0 wins, 1 if player 1 wins and -1 if it is a draw
     # first check if there was timeout, crash, invalid action or quit

--- a/pontu_tools.py
+++ b/pontu_tools.py
@@ -15,6 +15,7 @@ def play_game(init_state, names, players, total_time, display_gui):
     invalidaction = -1
     quit = -1
     exception = ''
+    full_trace = ''
     action = None
     last_action = None
     if display_gui:
@@ -36,11 +37,14 @@ def play_game(init_state, names, players, total_time, display_gui):
             timedout = cur_player
             state.set_timed_out(cur_player)
             break
-        except Exception as e:
+        except Exception:
             trace = traceback.format_exc().split('\n')
+            # Use `exception` as error abbrev. and `full_trace` for the full trace stack
             exception = trace[len(trace) - 2]
+            full_trace = traceback.format_exc()
             # set that the current player crashed
             crashed = cur_player
+            timer_stop[0] = True
             break
         else:
             # update time
@@ -70,7 +74,15 @@ def play_game(init_state, names, players, total_time, display_gui):
                 break
         if display_gui:
             timer.join()
-    if display_gui:
+    
+    # When the game crashed, print the error message in the console
+    # and tell the user (watching the screen) that there was an error
+    # Don't display the winner - there is non on game crash, so it
+    # would be a tie, which can lead to confusion.
+    if crashed != -1:
+        gui.display_crash(state)
+        print(full_trace)
+    elif display_gui:
         gui.display_winner(state)
 
     # output the result of the game: 0 if player 0 wins, 1 if player 1 wins and -1 if it is a draw

--- a/pontu_tools.py
+++ b/pontu_tools.py
@@ -5,7 +5,7 @@ import signal
 import traceback
 from threading import Thread
 
-def play_game(init_state, names, players, total_time, display_gui):
+def play_game(init_state, names, players, total_time, display_gui, verbosity):
     # create the initial state
     state = init_state
     # initialize the time left for each player
@@ -81,7 +81,6 @@ def play_game(init_state, names, players, total_time, display_gui):
     # would be a tie, which can lead to confusion.
     if crashed != -1:
         gui.display_crash(state)
-        print(full_trace)
     elif display_gui:
         gui.display_winner(state)
 
@@ -91,6 +90,8 @@ def play_game(init_state, names, players, total_time, display_gui):
         return (1 - timedout, names[timedout] + ' timed out', total_time - time_left[0], total_time - time_left[1],
                 state.get_scores())
     elif crashed != -1:
+        if verbosity > 0:
+            print(full_trace)
         return (
         1 - crashed, names[crashed] + ' crashed: ' + exception, total_time - time_left[0], total_time - time_left[1],
         state.get_scores())

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ You can run a match by executing the ```pontu_play.py``` script as follows (you 
            indicates the player (0 or 1) that plays first; random otherwise
       -g   
            display GUI (true or false); by default true
+      -v,  --verbosity
+           Increase output verbosity (maximum is 3)
 
 
 **Examples:**
@@ -45,6 +47,8 @@ You can run a match by executing the ```pontu_play.py``` script as follows (you 
         python pontu_play.py -ai0 ai_0 -ai1 ai_1 -f 0 -g true
 
         python pontu_play.py -ai0 random_agent -ai1 human_agent -f 1 -g true
+
+        python pontu_play.py -ai0 random_agent -ai1 my_agent -g true -v
 
 ### Allowed time for each AI
 The ```-t``` option allows you to specify the overall time (in seconds) allowed for all AI moves of each agent. If an agent exceeds his budget, he automatically loses the game.


### PR DESCRIPTION
Hi!

Sometimes, the AI agent used is incorrectly implemented and causes the game to crash. This leads to the game window to display a message that the game is a tie, however there actually was an execution error.
To help students (and people like me) see that there was an error, this PR implements a system with a new message in the display window and prints out the full error trace for debugging purposes.

**Change added**
![Game crash message example](https://user-images.githubusercontent.com/19630890/227794131-22622043-7f5c-4eb0-a1a7-8022826f2348.png)

**How to test**
Duplicate the `random_agent` and `raise Exception()` instead of returning an action. Then execute the game like a normal agent.